### PR TITLE
spelling: WebAseembly -> WebAssembly

### DIFF
--- a/wasm-respec.html
+++ b/wasm-respec.html
@@ -45,7 +45,7 @@
   <body>
     <section id="abstract"><span class="secno>1</span> <span class="content>
         This document describes version 1.0 of the core WebAssembly standard, a safe, portable, low-level code format designed for efficient execution and compact representation.
-        WebAseembly Core is part of a collection of WebAssembly specifications:
+        WebAssembly Core is part of a collection of WebAssembly specifications:
         the <a href="https://www.w3.org/TR/wasm-core/">Core WebAssembly Specification</a>,
         the <a href="https://www.w3.org/TR/wasm-js-api/">WebAssembly JS Interface</a>,
         and the <a href="https://www.w3.org/TR/wasm-web-api/">WebAssembly Web API</a>.


### PR DESCRIPTION
An identical typo is also visible in the recently publicized [wasm-core-2 TR](https://www.w3.org/TR/wasm-core-2/). I haven't been able to find the template from which that was generated, but I assume it's replicated from this one.